### PR TITLE
Update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "dkd/solr-typo3-devbox"
   config.vm.box_version = "5.1.1"
+  config.ssh.shell = 'sh'
   # if you want to use a local box
   # can be used when downloaded e.g. from https://app.vagrantup.com/dkd/boxes/solr-typo3-devbox/versions/<version>/providers/virtualbox.box
   # config.vm.box_url ="file:///"


### PR DESCRIPTION
I had to add this line to make the box run on (ubuntu-) linux, because bash messes up stuff with NFS 

After runnning vagrant up I got the following error:
´´´
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

set -e
mkdir -p /vagrant
mount -o vers=3,udp 192.168.57.1:/home/lars/vagrant/solr-typo3-devbox-5.1.1 /vagrant
if command -v /sbin/init && /sbin/init --version | grep upstart; then
  /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=/vagrant
fi


Stdout from the command:



Stderr from the command:

mesg: ttyname failed: Inappropriate ioctl for device
mount.nfs: access denied by server while mounting 192.168.57.1:/home/lars/vagrant/solr-typo3-devbox-5.1.1
´´´